### PR TITLE
feat:[013-SEARCH] 상점이름 검색 , 상품검색 기능

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - "8085:8080"
     depends_on:
       - redis
-      - elasticsearch
+#      - elasticsearch
 
   redis:
     image: redis:latest
@@ -20,14 +20,14 @@ services:
     ports:
       - "6379:6379"
 
-  elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.12.1
-    container_name: cm-elasticsearch
-    environment:
-      - "discovery.type=single-node"
-    ports:
-      - "9200:9200"
-      - "9300:9300"
+#  elasticsearch:
+#    image: docker.elastic.co/elasticsearch/elasticsearch:8.12.1
+#    container_name: cm-elasticsearch
+#    environment:
+#      - "discovery.type=single-node"
+#    ports:
+#      - "9200:9200"
+#      - "9300:9300"
 
   nginx:
     image: nginx:latest

--- a/src/main/java/com/saechan/collectormarket/product/controller/ProductController.java
+++ b/src/main/java/com/saechan/collectormarket/product/controller/ProductController.java
@@ -1,11 +1,14 @@
 package com.saechan.collectormarket.product.controller;
 
 import com.saechan.collectormarket.product.dto.request.ProductCreateForm;
+import com.saechan.collectormarket.product.dto.request.ProductSearchForm;
 import com.saechan.collectormarket.product.dto.request.ProductUpdateForm;
 import com.saechan.collectormarket.product.dto.response.ProductDto;
+import com.saechan.collectormarket.product.dto.response.ProductSearchDto;
 import com.saechan.collectormarket.product.service.ProductService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -21,6 +24,10 @@ public class ProductController {
 
   private final ProductService productService;
 
+  private final String DEFAULT_PAGE_NUM = "0";
+  private final String DEFAULT_PAGE_SIZE = "10";
+
+  // 상품 생성
   @PostMapping("/create")
   public ResponseEntity<ProductDto> createProduct(
       Authentication authentication,
@@ -31,6 +38,7 @@ public class ProductController {
     return ResponseEntity.ok(productDto);
   }
 
+  // 상품 수정
   @PutMapping("/update")
   public ResponseEntity<ProductDto> updateProduct(
       Authentication authentication,
@@ -42,6 +50,7 @@ public class ProductController {
     return ResponseEntity.ok(productDto);
   }
 
+  // 상품 삭제
   @DeleteMapping("/delete")
   public ResponseEntity<Void> deleteProduct(
       Authentication authentication,
@@ -52,13 +61,25 @@ public class ProductController {
     return ResponseEntity.noContent().build();
   }
 
+  // 상품 상세정보 보기
   @GetMapping("/view")
   public ResponseEntity<ProductDto> viewProduct(
       Authentication authentication,
       @RequestParam long id
   ){
-    String memberEmail = authentication.getName();
-    ProductDto productDto = productService.view(memberEmail, id);
+    ProductDto productDto = productService.view(id);
     return ResponseEntity.ok(productDto);
+  }
+
+  // 상품 검색 ( 이름, 가격, 상태, 카테고리, 거래상태 )
+  @GetMapping("/search")
+  public ResponseEntity<Page<ProductSearchDto>> searchProduct(
+      Authentication authentication,
+      @Valid @ModelAttribute ProductSearchForm form,
+      @RequestParam(defaultValue = DEFAULT_PAGE_NUM) int page,
+      @RequestParam(defaultValue = DEFAULT_PAGE_SIZE) int size
+  ){
+    Page<ProductSearchDto> productSearchDtos = productService.search(form,page,size);
+    return ResponseEntity.ok(productSearchDtos);
   }
 }

--- a/src/main/java/com/saechan/collectormarket/product/dto/request/ProductSearchForm.java
+++ b/src/main/java/com/saechan/collectormarket/product/dto/request/ProductSearchForm.java
@@ -1,0 +1,31 @@
+package com.saechan.collectormarket.product.dto.request;
+
+import com.saechan.collectormarket.product.model.type.ProductCategory;
+import com.saechan.collectormarket.product.model.type.ProductStatus;
+import com.saechan.collectormarket.transaction.model.type.TransactionStatus;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+import lombok.Builder.Default;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ProductSearchForm {
+
+  @NotNull
+  @Size(max = 20)
+  private String name;
+
+  @Default
+  private Double minPrice = 0.0;
+
+  @Default
+  private Double maxPrice = Double.POSITIVE_INFINITY;
+
+  private ProductStatus productStatus;
+
+  private ProductCategory productCategory;
+
+  private TransactionStatus transactionStatus;
+}

--- a/src/main/java/com/saechan/collectormarket/product/dto/response/ProductDto.java
+++ b/src/main/java/com/saechan/collectormarket/product/dto/response/ProductDto.java
@@ -17,6 +17,8 @@ import lombok.Setter;
 @Builder
 public class ProductDto {
 
+  private Long id;
+
   private String name;
 
   private String description;
@@ -39,6 +41,7 @@ public class ProductDto {
 
   public static ProductDto from(Product product){
     return ProductDto.builder()
+        .id(product.getId())
         .name(product.getName())
         .description(product.getDescription())
         .price(product.getPrice())

--- a/src/main/java/com/saechan/collectormarket/product/dto/response/ProductSearchDto.java
+++ b/src/main/java/com/saechan/collectormarket/product/dto/response/ProductSearchDto.java
@@ -1,0 +1,33 @@
+package com.saechan.collectormarket.product.dto.response;
+
+import com.saechan.collectormarket.product.model.entity.Product;
+import com.saechan.collectormarket.transaction.model.type.TransactionStatus;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class ProductSearchDto {
+  private Long id;
+
+  private String name;
+
+  private Double price;
+
+  // 썸네일 이미지 주소
+  private String imageUrl;
+
+  private TransactionStatus transactionStatus;
+
+  public static ProductSearchDto from(Product product){
+    return ProductSearchDto.builder()
+        .id(product.getId())
+        .name(product.getName())
+        .price(product.getPrice())
+        .imageUrl(product.getProductImages().getFirst().getImageUrl())
+        .transactionStatus(product.getTransactionStatus())
+        .build();
+  }
+}

--- a/src/main/java/com/saechan/collectormarket/product/model/repository/ProductImageRepository.java
+++ b/src/main/java/com/saechan/collectormarket/product/model/repository/ProductImageRepository.java
@@ -2,6 +2,8 @@ package com.saechan.collectormarket.product.model.repository;
 
 import com.saechan.collectormarket.product.model.entity.ProductImage;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface ProductImageRepository extends JpaRepository<ProductImage,Long> {
 }

--- a/src/main/java/com/saechan/collectormarket/product/model/repository/ProductRepository.java
+++ b/src/main/java/com/saechan/collectormarket/product/model/repository/ProductRepository.java
@@ -1,10 +1,32 @@
 package com.saechan.collectormarket.product.model.repository;
 
 import com.saechan.collectormarket.product.model.entity.Product;
+import com.saechan.collectormarket.product.model.type.ProductCategory;
+import com.saechan.collectormarket.product.model.type.ProductStatus;
+import com.saechan.collectormarket.transaction.model.type.TransactionStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ProductRepository extends JpaRepository<Product, Long> {
 
+  @Query("SELECT product FROM Product product"
+      + " WHERE (product.name LIKE %:name% )"
+      + " AND (:minPrice IS NULL OR product.price >= :minPrice)"
+      + " AND (:maxPrice IS NULL OR product.price <= :maxPrice)"
+      + " AND (:productStatus IS NULL OR product.productStatus = :productStatus)"
+      + " AND (:productCategory IS NULL OR product.productCategory = :productCategory)"
+      + " AND (:transactionStatus IS NULL OR product.transactionStatus = :transactionStatus)")
+  Page<Product> findByNameWithFiltering(
+      @Param("name") String name,
+      @Param("minPrice") Double minPrice,
+      @Param("maxPrice") Double maxPrice,
+      @Param("productStatus") ProductStatus productStatus,
+      @Param("productCategory") ProductCategory productCategory,
+      @Param("transactionStatus") TransactionStatus transactionStatus,
+      Pageable pageable);
 }

--- a/src/main/java/com/saechan/collectormarket/store/controller/StoreController.java
+++ b/src/main/java/com/saechan/collectormarket/store/controller/StoreController.java
@@ -2,6 +2,7 @@ package com.saechan.collectormarket.store.controller;
 
 import com.saechan.collectormarket.store.dto.request.StoreUpdateForm;
 import com.saechan.collectormarket.store.dto.response.StoreDto;
+import com.saechan.collectormarket.store.dto.response.StoreSearchDto;
 import com.saechan.collectormarket.store.service.StoreService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -10,8 +11,8 @@ import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -21,8 +22,9 @@ import org.springframework.web.bind.annotation.RestController;
 public class StoreController {
   private final StoreService storeService;
 
+  // 자신의 상점 업데이트
   @PutMapping("/update")
-  public ResponseEntity<StoreDto> update(
+  public ResponseEntity<StoreDto> storeUpdate(
       Authentication authentication,
       @ModelAttribute StoreUpdateForm form
   ){
@@ -31,13 +33,24 @@ public class StoreController {
     return ResponseEntity.ok(storeDto);
   }
 
+  // 상점 상세보기
   @GetMapping("/profile")
-  public ResponseEntity<StoreDto> profile(
-      Authentication authentication
+  public ResponseEntity<StoreDto> storeProfile(
+      Authentication authentication,
+      @RequestParam Long storeId
   ){
-    String memberEmail = authentication.getName();
-    StoreDto storeDto = storeService.getProfile(memberEmail);
+    StoreDto storeDto = storeService.getProfile(storeId);
     return ResponseEntity.ok(storeDto);
+  }
+
+  // 상점 검색
+  @GetMapping("/search")
+  public ResponseEntity<StoreSearchDto> searchStoreByName(
+      Authentication authentication,
+      @RequestParam String storeName
+  ){
+    StoreSearchDto storeSearchDto = storeService.getStoreByName(storeName);
+    return ResponseEntity.ok(storeSearchDto);
   }
 
 }

--- a/src/main/java/com/saechan/collectormarket/store/dto/response/StoreDto.java
+++ b/src/main/java/com/saechan/collectormarket/store/dto/response/StoreDto.java
@@ -16,11 +16,13 @@ import lombok.Setter;
 @Builder
 public class StoreDto {
 
+  private Long id;
+
   private String name;
 
   private String description;
 
-  private String image;
+  private String imageUrl;
 
   private LocalDateTime openDt;
 
@@ -36,9 +38,10 @@ public class StoreDto {
 
   public static StoreDto from(Store store) {
     return StoreDto.builder()
+        .id(store.getId())
         .name(store.getName())
         .description(store.getDescription())
-        .image(store.getImageUrl())
+        .imageUrl(store.getImageUrl())
         .openDt(store.getOpenDt())
         .productIds(store.getProducts().stream()
             .map(Product::getId)

--- a/src/main/java/com/saechan/collectormarket/store/dto/response/StoreSearchDto.java
+++ b/src/main/java/com/saechan/collectormarket/store/dto/response/StoreSearchDto.java
@@ -1,0 +1,29 @@
+package com.saechan.collectormarket.store.dto.response;
+
+import com.saechan.collectormarket.store.model.entity.Store;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class StoreSearchDto {
+
+  private Long id;
+
+  private String name;
+
+  private String imageUrl;
+
+  private Integer productNumber;
+
+  public static StoreSearchDto from(Store store){
+    return StoreSearchDto.builder()
+        .id(store.getId())
+        .name(store.getName())
+        .imageUrl(store.getImageUrl())
+        .productNumber(store.getProducts().size())
+        .build();
+  }
+}

--- a/src/main/java/com/saechan/collectormarket/store/model/repository/StoreRepository.java
+++ b/src/main/java/com/saechan/collectormarket/store/model/repository/StoreRepository.java
@@ -10,4 +10,6 @@ public interface StoreRepository extends JpaRepository<Store,Long> {
 
   @Override
   Optional<Store> findById(Long storeId);
+
+  Optional<Store> findByName(String storeName);
 }

--- a/src/main/java/com/saechan/collectormarket/store/service/StoreService.java
+++ b/src/main/java/com/saechan/collectormarket/store/service/StoreService.java
@@ -8,6 +8,7 @@ import com.saechan.collectormarket.member.model.entity.Member;
 import com.saechan.collectormarket.member.service.MemberUtils;
 import com.saechan.collectormarket.store.dto.request.StoreUpdateForm;
 import com.saechan.collectormarket.store.dto.response.StoreDto;
+import com.saechan.collectormarket.store.dto.response.StoreSearchDto;
 import com.saechan.collectormarket.store.exception.StoreException;
 import com.saechan.collectormarket.store.model.entity.Store;
 import com.saechan.collectormarket.store.model.repository.StoreRepository;
@@ -25,6 +26,7 @@ public class StoreService {
 
   private final ImageUploadService imageUploadService;
 
+  // 상점 생성 (회원생성시 자동생성)
   public Store createStore(Member member) {
 
     Store store = Store.builder()
@@ -43,6 +45,7 @@ public class StoreService {
     return storeRepository.save(store);
   }
 
+  // 자신의 상점 수정
   public StoreDto update(String memberEmail, StoreUpdateForm form) {
     // 회원 검증
     Member member = MemberUtils.verifyMemberFromEmail(memberEmail);
@@ -60,7 +63,8 @@ public class StoreService {
     // Form 이미지 파일 존재시
     if (!form.getImage().isEmpty()) {
       // 이미지 S3 업로드 -> 상점 업데이트
-      store.setImageUrl(imageUploadService.uploadStoreImage(form.getImage(), ImageProperty.STORE, store.getId()));
+      store.setImageUrl(imageUploadService.uploadStoreImage(form.getImage(),
+          ImageProperty.STORE, store.getId()));
     }
 
     // 상점 업데이트
@@ -71,13 +75,20 @@ public class StoreService {
     return StoreDto.from(storeRepository.save(store));
   }
 
-  public StoreDto getProfile(String memberEmail) {
-    // 회원 검증
-    Member member = MemberUtils.verifyMemberFromEmail(memberEmail);
-
+  // 상점 상세 보기
+  public StoreDto getProfile(Long storeId) {
     // 상점 검증
-    return StoreDto.from(
-        storeRepository.findById(member.getStore().getId())
-            .orElseThrow(() -> new StoreException(ErrorCode.STORE_NOT_FOUND)));
+    Store store = storeRepository.findById(storeId)
+        .orElseThrow(() -> new StoreException(ErrorCode.STORE_NOT_FOUND));
+    return StoreDto.from(store);
+  }
+
+  // 상점 이름 검색
+  public StoreSearchDto getStoreByName(String storeName) {
+    // 상점 검증
+    return StoreSearchDto.from(
+        storeRepository.findByName(storeName)
+            .orElseThrow(() -> new StoreException(ErrorCode.STORE_NOT_FOUND))
+    );
   }
 }


### PR DESCRIPTION
**ES 기능을 3일동안 시도해보았으나 (apache sorl로도 시도해봤으나 실패했습니다) 서버는 잘작동하는데 서버에 applicaton이 연결되지않네요. 원인을 찾지 못했어요...(branch(011,012) 로만 남겨둔 상태입니다.) 우선은 일반적인 DB 작업으로 검색기능을 구현하고자합니다. **

Changes
---
**TO-BE**
- 상점 검색 : 상점이름과 정확히 일치하게 검색해야합니다.
  - 반환값으로 상점의 이름, 썸네일 이미지 URL, 상점의 전체상품갯수, 이름, ID를 불러옴

- 상품 검색 : 상품 이름을 포함한 상품들을 나열합니다. 상품 가격, 상태, 카테고리, 거래상태에 따라서 필터링 기능도 제공합니다. 상품이름은 필수항목입니다.
  - 페이징기능, Repository단에서 @query를 통항 필터링기능 구현
  - 반환값으로 상품 id, 이름, 가격, 썸네일 이미지주소, 거래상태의 ProductSearchDto 페이지 묶음을 가져옵니다.

- API 주소 -> 수정사항
  - product/view : 기존 나의 상품만 보는것에서 로그인된 회원 아무나 상품id만 입력하면 볼수있도록 수정
  - store/profile : 기존 나의 상점만 보는것에서 로그인된 회원 아무나 상점id를 입력하면 볼수있도록 수정

TEST
---
- [ ] Test - Code
- [X] API - Test